### PR TITLE
Fix an issue with the umd.js and RequireJS

### DIFF
--- a/src/helpers/fixRequireJsIssue.ts
+++ b/src/helpers/fixRequireJsIssue.ts
@@ -1,0 +1,22 @@
+import MagicString from "magic-string";
+
+const fixRequireJsIssue = () => ({
+  name: "fixRequireJsIssue",
+  enforce: "pre",
+  transform: (src, path) => {
+    const filter = /node_modules\/.*\.[jt]sx?/;
+    if (!path.match(filter)) { return; }
+
+    const filename = path.replace(/^.*[\\/]/, "");
+    const source = new MagicString(src, { filename });
+
+    source.prepend("var define = false;\n");
+
+    const code = source.toString();
+    const map = source.generateMap({ source: filename });
+
+    return { code, map };
+  },
+});
+
+export default fixRequireJsIssue;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,13 @@
 import { resolve } from "path"
 import { defineConfig } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
+import fixRequireJsIssue from "./src/helpers/fixRequireJsIssue";
 import makeCssImportant from "./src/helpers/makeCssImportant";
 import prefixCssSelectors from "./src/helpers/prefixCssSelectors";
 
 export default defineConfig({
   plugins: [
+    fixRequireJsIssue(),
     svelte({ emitCss: true, compilerOptions: { accessors: true } }),
     makeCssImportant({ type: "inline-styles" }),
     makeCssImportant({ type: "style-tags" }),


### PR DESCRIPTION
When the umd.js script is loaded with an async tag and RequireJS is already loaded on the page, it results in an error. This commit adds a Vite plugin based on this one:

https://github.com/pakholeung37/vite-plugin-treat-umd-as-commonjs/blob/master/src/index.ts#L19

The NPM package above hasn’t been updated in a while and its dependencies aren’t compatible with Svelte 4 and the plugin did not try to keep the sourcemap intact. Therefore, recreate the plugin ourselves.