### PR TITLE
Fix width based styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "hls.js": "^1.3",
         "jsdom": "^22.0",
         "postcss": "^8.4",
+        "resize-observer-polyfill": "^1.5",
         "stacktrace-parser": "^0.1",
         "svelte": "^4.1",
         "uuid": "^9.0",
@@ -2785,6 +2786,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
       "dev": true
     },
     "node_modules/resolve-from": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "hls.js": "^1.3",
     "jsdom": "^22.0",
     "postcss": "^8.4",
+    "resize-observer-polyfill": "^1.5",
     "stacktrace-parser": "^0.1",
     "svelte": "^4.1",
     "uuid": "^9.0",

--- a/src/components/UserInterface.svelte
+++ b/src/components/UserInterface.svelte
@@ -147,7 +147,7 @@
 
   onMount(() => {
     const observer = new ResizeObserver(([entry]) => {
-      width = entry.contentRect.width
+      width = entry.contentRect.width;
     });
     observer.observe(element);
     return () => observer.unobserve(element);

--- a/src/components/UserInterface.svelte
+++ b/src/components/UserInterface.svelte
@@ -1,7 +1,9 @@
 <script>
   import("../helpers/loadTheStyles.ts");
   import "@fontsource/inter/variable.css";
+  import { onMount } from "svelte";
   import { fly } from "svelte/transition";
+  import ResizeObserver from "resize-observer-polyfill";
   import PlayPauseButton from "./buttons/PlayPauseButton.svelte";
   import PlaybackRateButton from "./buttons/PlaybackRateButton.svelte";
   import PrevButton from "./buttons/PrevButton.svelte";
@@ -65,7 +67,7 @@
   export let isVisible = undefined;
   export let relativeY = undefined;
   export let absoluteY = undefined;
-  let width, isHovering, timeout;
+  let element, width, isHovering, timeout;
 
   $: isSmall = playerStyle === "small";
   $: isStandard = playerStyle === "standard";
@@ -142,9 +144,17 @@
       initiatedBy: "user",
     }));
   };
+
+  onMount(() => {
+    const observer = new ResizeObserver(([entry]) => {
+      width = entry.contentRect.width
+    });
+    observer.observe(element);
+    return () => observer.unobserve(element);
+  });
 </script>
 
-<div class={classes} style="width: {widthStyle}" class:mobile={isMobile} class:advert_={isAdvert} class:hovering={isHovering} class:collapsed bind:clientWidth={width} class:animating={timeout} transition:flyWidget|global on:outrostart={animate}>
+<div bind:this={element} class={classes} style="width: {widthStyle}" class:mobile={isMobile} class:advert_={isAdvert} class:hovering={isHovering} class:collapsed class:animating={timeout} transition:flyWidget|global on:outrostart={animate}>
   <Hoverable bind:isHovering exitDelay={collapsible ? 500 : 0} idleDelay={isVideo ? 1500 : Infinity}>
     {#if isVideo && (videoPosterImage || !videoIsBehind)}
       <div class="video-placeholder" style={videoPosterImage ? `background-image: url(${videoPosterImage})` : ""}>


### PR DESCRIPTION
The Svelte api `bind:clientWidth` results in width being evaluated as 0px sometimes, which causes the `mobile` css class to be applied to the container element of the UserInterface component.