### PR TITLE
fix findLoadedMedia helper function

### DIFF
--- a/src/helpers/findLoadedMedia.ts
+++ b/src/helpers/findLoadedMedia.ts
@@ -15,7 +15,7 @@ const srcWithoutHash = (src) => {
   let url;
   try { url = new URL(src); } catch (e) { return src; }
   if (!url.hash) { return src; }
-  return src.slice(0, -url.hash.length);
+  return src?.slice(0, -url.hash.length);
 };
 
 const absoluteUrl = (url) => {


### PR DESCRIPTION
ignore the time fragment in the video currentSrc