### PR TITLE
Fix sending `duration: "Infinity"` to Google Analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
       const script = document.querySelector("#player-script");
       const isLocal = location.hostname === "localhost" || location.hostname.includes("ngrok-free");
 
-      script.src = isLocal ? "src/index.ts" : "https://proxy.beyondwords.io/npm/@beyondwords/player@0.3.1/dist/umd.js";
+      script.src = isLocal ? "src/index.ts" : "https://proxy.beyondwords.io/npm/@beyondwords/player@0.3.2/dist/umd.js";
     </script>
 
     <p data-beyondwords-marker="76fe8780-09ef-4a35-b5ac-31122bdf0c79">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@beyondwords/player",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@beyondwords/player",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "See license in README.md",
       "devDependencies": {
         "@axe-core/playwright": "^4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beyondwords/player",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "See license in README.md",
   "author": "BeyondWords Developers",
   "homepage": "https://github.com/BeyondWords-io/player",

--- a/src/helpers/sendToAnalytics.ts
+++ b/src/helpers/sendToAnalytics.ts
@@ -51,7 +51,9 @@ const eventFromProps = (player, analyticsEventType) => {
 
   const activeAdvert = player.adverts[player.advertIndex];
   const contentItem = player.content[player.contentIndex];
-  const percentage = player.duration ? (player.currentTime / player.duration) * 100 : 0;
+
+  const duration = (player.duration === Infinity) ? 0 : player.duration || 0;
+  const percentage = player.currentTime / duration * 100;
 
   return {
     event_type: analyticsEventType,
@@ -68,7 +70,7 @@ const eventFromProps = (player, analyticsEventType) => {
     local_storage_id: withoutStorage ? null : JSON.parse(localStorage.beyondwords),
     listen_session_id: player.listenSessionId,
     session_created_at: player.sessionCreatedAt,
-    duration: player.duration,
+    duration: duration,
     listen_length_seconds: player.currentTime,
     listen_length_percent: Math.max(0, Math.min(100, percentage)),
     speed: player.playbackRate,


### PR DESCRIPTION
https://linear.app/beyondwords/issue/S-6004/bug-integration-with-ga4

I'm not sure exactly why it's happening but we should at least send a value of the correct type.